### PR TITLE
ファルルの表記揺れを統一してみた（Faluluに統一）

### DIFF
--- a/_data/pripara-characters.csv
+++ b/_data/pripara-characters.csv
@@ -9,7 +9,7 @@ kurosu_aroma,黒須 あろま,くろす あろま,牧野由依,6月6日,A型,カ
 shiratama_mikan,白玉 みかん,しらたま みかん,渡部優衣,10月4日,B型,プリン、中華まん,Silky Heart（シルキーハート）、LOVE DEVI（ラブデビ）,ラブリー
 gaaruru,ガァルル,,真田アサミ,4月17日,,アーモンドクッキー,Marionette Mu（マリオネットミュー）、LOVE DEVI（ラブデビ）,ラブリー
 shikyoin_hibiki,紫京院 ひびき,しきょういん ひびき,斎賀みつき,3月27日,B型,ガトーショコラ,Brilliant Prince（ブリリアントプリンス）,セレブ
-faruru,ファルル,,赤﨑千夏,3月21日,,牛乳,Marionette Mu（マリオネットミュー）,ラブリー
+falulu,ファルル,,赤﨑千夏,3月21日,,牛乳,Marionette Mu（マリオネットミュー）,ラブリー
 midorikaze_fuwari,緑風 ふわり,みどりかぜ ふわり,佐藤あずさ,8月11日,O型,お寿司,Coco Flower（ココフラワー）,ナチュラル
 manaka_non,真中 のん,まなか のん,田中美海,9月6日,A型,パスタ,Twinkle Ribbon Sweet（トゥインクルリボンスウィート）,
 tsukikawa_chiri,月川 ちり,つきかわ ちり,大森日雅,11月15日,AB型,栗きんとん,Dear Crown（ディアクラウン）,

--- a/_data/pripara-lives.csv
+++ b/_data/pripara-lives.csv
@@ -113,10 +113,10 @@ episode,song,team
 57,tondemo_summer_adventure,dressing_flower
 88,tondemo_summer_adventure,dressing_flower
 110,tondemo_summer_adventure,dressing_flower
-58,love_week_old,faruru
-70,love_week_old,faruru
-75,love_week_old,faruru
-133,love_week_old,faruru
+58,love_week_old,falulu
+70,love_week_old,falulu
+75,love_week_old,falulu
+133,love_week_old,falulu
 80,love_week_old,gaaruru
 81,love_week_old,gaaruru
 83,love_week_old,gaaruru

--- a/_data/pripara-song-character.csv
+++ b/_data/pripara-song-character.csv
@@ -1,13 +1,13 @@
 song,character
 make_it,minami_mirei
 taiyo_no_flare_serbet,hojo_sophie
-zero_week_old,faruru
+zero_week_old,falulu
 kimi_100_percent_jinse,hojo_cosmo
 dream_parade,manaka_laala
 dream_parade,minami_mirei
 taiyo_no_flare_serbet_sakura_shower_ver,hojo_sophie
 konouta_tomareihi,midorikaze_fuwari
-love_week_old,faruru
+love_week_old,falulu
 love_week_old,gaaruru
 zettai_seimei_final_show_jo,todo_shion
 panic_labyrinth,kiki_ajimi

--- a/_data/pripara-team-characters.csv
+++ b/_data/pripara-team-characters.csv
@@ -17,7 +17,7 @@ triangle,junon
 triangle,pinon
 triangle,kanon
 tricolore,shikyoin_hibiki
-tricolore,faruru
+tricolore,falulu
 tricolore,midorikaze_fuwari
 non_sugar,non_manaka
 non_sugar,chiri_tsukikawa


### PR DESCRIPTION
むずくないこれ

https://en.wikipedia.org/wiki/PriPara#Tricolore

これ見た感じでも `Falulu` なので。ついでに改行コードの揺れも直してみた。