### PR TITLE
RDF生成時にrdf:typeをつける

### DIFF
--- a/_data/convert-settings/pripara-characters-setting.json
+++ b/_data/convert-settings/pripara-characters-setting.json
@@ -2,5 +2,6 @@
     "subjectBaseUrl": "/rdfs/characters/",
     "PredicateBaseUrl": "/preds/",
     "dataCsvPath": "../_data/pripara-characters.csv",
-    "columnsCsvPath": "../_data/convert-settings/pripara-characters-columns.csv"
+    "columnsCsvPath": "../_data/convert-settings/pripara-characters-columns.csv",
+    "rdfType": "$BASE_URL/prism-schema.ttl#Character"
 }

--- a/csv2rdf/csv2rdf.ts
+++ b/csv2rdf/csv2rdf.ts
@@ -10,6 +10,7 @@ interface Setting {
     PredicateBaseUrl: string
     dataCsvPath: string
     columnsCsvPath: string
+    rdfType: string
 }
 
 const addQuad = (store: N3.N3Store, key, predicate, subject, setting: Setting) => {
@@ -52,6 +53,13 @@ export default class {
         const datas = await getDatas(setting.dataCsvPath)
         const columns = await getColumns(setting.columnsCsvPath)
         datas.forEach(row => {
+            if (setting.rdfType) {
+                this.store.addQuad(
+                    process.env.BASE_URL + setting.subjectBaseUrl + row["key"],
+                    namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+                    namedNode(setting.rdfType.replace("$BASE_URL", process.env.BASE_URL))
+                );
+            }
             columns.forEach(col => {
                 if (row[col.key].length > 0) addQuad(this.store, row["key"], col.prdicate, row[col.key], setting)
             })


### PR DESCRIPTION
closes #27 

プライマリーのCSV (マスター) ごとに `-setting.json` で指定したクラスでrdf:typeを埋めます。設定はプライマリーのCSVごとなので，CSVの各行は同じクラスである必要があります(が，そのほうが分かりやすいはず)。

たとえばpripara-characters.csvの各行が `$BASE_URL/prism-schema.ttl#Character` のときの設定がこのPRに含まれていますが，型のIRIがどこにあるのか(語彙のttlがどこにあるのか)を `/prism-schema.ttl`と仮置きして書いています(そこが変われば合わせて変える必要がある)。