### PR TITLE
CSV2RDF  にて $baseurl を全面的に使えるように修正

### DIFF
--- a/_data/convert-settings/pripara-characters-setting.json
+++ b/_data/convert-settings/pripara-characters-setting.json
@@ -1,6 +1,6 @@
 {
-    "subjectBaseUrl": "/rdfs/characters/",
-    "PredicateBaseUrl": "/preds/",
+    "subjectBaseUrl": "$BASE_URL/rdfs/characters/",
+    "PredicateBaseUrl": "$BASE_URL/preds/",
     "dataCsvPath": "../_data/pripara-characters.csv",
     "columnsCsvPath": "../_data/convert-settings/pripara-characters-columns.csv",
     "rdfType": "$BASE_URL/prism-schema.ttl#Character"

--- a/_data/convert-settings/pripara-characters-setting.json
+++ b/_data/convert-settings/pripara-characters-setting.json
@@ -1,6 +1,6 @@
 {
     "subjectBaseUrl": "$BASE_URL/rdfs/characters/",
-    "PredicateBaseUrl": "$BASE_URL/preds/",
+    "PredicateBaseUrl": "$BASE_URL/prism-schema.ttl#",
     "dataCsvPath": "../_data/pripara-characters.csv",
     "columnsCsvPath": "../_data/convert-settings/pripara-characters-columns.csv",
     "rdfType": "$BASE_URL/prism-schema.ttl#Character"

--- a/csv2rdf/csv2rdf.ts
+++ b/csv2rdf/csv2rdf.ts
@@ -15,8 +15,8 @@ interface Setting {
 
 const addQuad = (store: N3.N3Store, key, predicate, subject, setting: Setting) => {
     store.addQuad(
-        namedNode(process.env.BASE_URL + setting.subjectBaseUrl + key), //主語
-        namedNode(process.env.BASE_URL + setting.PredicateBaseUrl + predicate), //述語
+        namedNode(setting.subjectBaseUrl + key), //主語
+        namedNode(setting.PredicateBaseUrl + predicate), //述語
         literal(subject) //目的語
     );
 }
@@ -36,9 +36,15 @@ const getColumns = async (path: string): Promise<{ key: string, prdicate: string
     return await getCsvData(path) as { key: string, prdicate: string }[]
 }
 
+const replaceBaseurl = (str:string) => str.replace("$BASE_URL", process.env.BASE_URL)
+
 const getSettings = async (filePath: string): Promise<Setting> => {
     const fullPath = path.join(process.cwd(), filePath)
-    return JSON.parse(fs.readFileSync(fullPath, 'utf8')) as Setting
+    const setting =  JSON.parse(fs.readFileSync(fullPath, 'utf8')) as Setting
+    setting.subjectBaseUrl = replaceBaseurl(setting.subjectBaseUrl)
+    setting.PredicateBaseUrl = replaceBaseurl(setting.PredicateBaseUrl)
+    setting.rdfType = replaceBaseurl(setting.rdfType)
+    return setting
 }
 
 export default class {
@@ -55,9 +61,9 @@ export default class {
         datas.forEach(row => {
             if (setting.rdfType) {
                 this.store.addQuad(
-                    process.env.BASE_URL + setting.subjectBaseUrl + row["key"],
+                    setting.subjectBaseUrl + row["key"],
                     namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
-                    namedNode(setting.rdfType.replace("$BASE_URL", process.env.BASE_URL))
+                    namedNode(setting.rdfType)
                 );
             }
             columns.forEach(col => {

--- a/csv2rdf/index.ts
+++ b/csv2rdf/index.ts
@@ -3,14 +3,17 @@ import * as fs from 'fs'
 import * as rimraf from 'rimraf'
 
 (async () => {
+  // virtuosoディレクトリを削除し，virtuoso/toLoadディレクトリを作成
   if(fs.existsSync('../virtuoso')) rimraf.sync('../virtuoso')
   fs.mkdirSync('../virtuoso')
   fs.mkdirSync('../virtuoso/toLoad')
 
+  // schema.ttl を作成
   // const csv2rdf_ = new Csv2rdf()
   // await csv2rdf_.load('./_data/ontology/prism-schema.json')
-  // await csv2rdf_.export('./virtuoso/toLoad/output.ttl')
+  // await csv2rdf_.export('./virtuoso/toLoad/schema.ttl')
 
+  // output.ttl(virtuosoにロードするデータ)を作成
   const csv2rdf = new Csv2rdf()
   await csv2rdf.load('../_data/convert-settings/pripara-characters-setting.json')
   await csv2rdf.export('../virtuoso/toLoad/output.ttl')


### PR DESCRIPTION
参考 #27  #32

- CSV2RDFにて使用するセッティング用のJSONでURLに `$BASE_URL` を挿入した際に，環境変数で設定した `BASE_URL` に置き換わるようにした
- それに伴ってセッティング用のJSONのURL記述部分にて `$BASE_URL` を使用
- `PredicateBaseUrl` のスキーマのパスを `prism-schema.ttl` へ変更
- CSV2RDFにて軽くコメントを追記
