### PR TITLE
プリパラとプリ☆チャンのライブcsvをRDF生成に追加

### DIFF
--- a/_data/convert-settings/prichan-lives-columns.csv
+++ b/_data/convert-settings/prichan-lives-columns.csv
@@ -1,4 +1,4 @@
-key,predicate,dataType,objectUriPrefix
-episode,liveOfEpisode,,https://prismdb.takanakahiko.me/rdfs/episodes/prichan_
-song,songPerformed,,
-team,performer,,
+key,predicate,dataType,objectUriPrefix,inversePredicate
+episode,liveOfEpisode,,$BASE_URL/rdfs/episodes/prichan_,livePerformed
+song,songPerformed,,,
+team,performer,,,

--- a/_data/convert-settings/prichan-lives-columns.csv
+++ b/_data/convert-settings/prichan-lives-columns.csv
@@ -1,6 +1,6 @@
 key,predicate,dataType,objectUriPrefix,inversePredicate
 episode,liveOfEpisode,,$BASE_URL/rdfs/episodes/prichan_,livePerformed
-song,songPerformed,,,
+song,songPerformed,,$BASE_URL/rdfs/songs/,performedInLive
 team,performer,,,
 start,start,http://www.w3.org/2001/XMLSchema#float,,
 end,end,http://www.w3.org/2001/XMLSchema#float,,

--- a/_data/convert-settings/prichan-lives-columns.csv
+++ b/_data/convert-settings/prichan-lives-columns.csv
@@ -1,4 +1,4 @@
-key,predicate,dataType
-episode,liveOfEpisode,
-song,songPerformed,
-team,performer,
+key,predicate,dataType,objectUriPrefix
+episode,liveOfEpisode,,https://prismdb.takanakahiko.me/rdfs/episodes/prichan_
+song,songPerformed,,
+team,performer,,

--- a/_data/convert-settings/prichan-lives-columns.csv
+++ b/_data/convert-settings/prichan-lives-columns.csv
@@ -2,3 +2,5 @@ key,predicate,dataType,objectUriPrefix,inversePredicate
 episode,liveOfEpisode,,$BASE_URL/rdfs/episodes/prichan_,livePerformed
 song,songPerformed,,,
 team,performer,,,
+start,start,http://www.w3.org/2001/XMLSchema#float,,
+end,end,http://www.w3.org/2001/XMLSchema#float,,

--- a/_data/convert-settings/prichan-lives-columns.csv
+++ b/_data/convert-settings/prichan-lives-columns.csv
@@ -1,0 +1,4 @@
+key,predicate,dataType
+episode,liveOfEpisode,
+song,songPerformed,
+team,performer,

--- a/_data/convert-settings/prichan-lives-setting.json
+++ b/_data/convert-settings/prichan-lives-setting.json
@@ -1,0 +1,8 @@
+{
+    "subjectBaseUrl": "$BASE_URL/rdfs/lives/",
+    "subjectKey": {"keys": ["episode", "song"], "pattern": "prichan_$0_$1"},
+    "PredicateBaseUrl": "$BASE_URL/prism-schema.ttl#",
+    "dataCsvPath": "../_data/prichan-lives.csv",
+    "columnsCsvPath": "../_data/convert-settings/prichan-lives-columns.csv",
+    "rdfType": "$BASE_URL/prism-schema.ttl#Live"
+}

--- a/_data/convert-settings/pripara-lives-columns.csv
+++ b/_data/convert-settings/pripara-lives-columns.csv
@@ -1,0 +1,4 @@
+key,predicate,dataType,objectUriPrefix,inversePredicate
+episode,liveOfEpisode,,$BASE_URL/rdfs/episodes/pripara_,livePerformed
+song,songPerformed,,$BASE_URL/rdfs/songs/,performedInLive
+team,performer,,,

--- a/_data/convert-settings/pripara-lives-setting.json
+++ b/_data/convert-settings/pripara-lives-setting.json
@@ -1,0 +1,8 @@
+{
+    "subjectBaseUrl": "$BASE_URL/rdfs/lives/",
+    "subjectKey": {"keys": ["episode", "song"], "pattern": "pripara_$0_$1"},
+    "PredicateBaseUrl": "$BASE_URL/prism-schema.ttl#",
+    "dataCsvPath": "../_data/pripara-lives.csv",
+    "columnsCsvPath": "../_data/convert-settings/pripara-lives-columns.csv",
+    "rdfType": "$BASE_URL/prism-schema.ttl#Live"
+}

--- a/_data/prichan-lives.csv
+++ b/_data/prichan-lives.csv
@@ -1,5 +1,5 @@
 episode,song,team,start,end
-1,レディー・アクション！,mirai_and_emo,1009,1136
-5,ワン・ツー・スウィーツ,mirai,1142.8,1236.2
-6,スキスキセンサー,emo,1073.8,1174.7
-52,TOKIMEKIハート・ジュエル♪,mirai,1130,1252
+1,ready_action,mirai_and_emo,1009,1136
+5,one_two_sweets,mirai,1142.8,1236.2
+6,suki_suki_sensor,emo,1073.8,1174.7
+52,tokimeki_heart_jewel,mirai,1130,1252

--- a/csv2rdf/README.md
+++ b/csv2rdf/README.md
@@ -106,7 +106,7 @@ hojo_sophie,北条 そふぃ,ほうじょう そふぃ,久保田未夢
 
 `characters-columns.csv`
 ```csv
-key,prdicate
+key,predicate
 名前,name
 かな,name_kana
 声優,cv
@@ -139,6 +139,14 @@ key,prdicate
 - `https://example.com/rdfs/characters/manaka_laala` の `https://example.com/preds/name_kana` が `"まなか らぁら"`
 
 みたいな意味です．
+
+カラム定義には下記のキーを指定できます．
+
+- `key`: `プライマリCSV` のどのカラムの値を参照するか
+- `predicate`: `key` を参照するときの述語
+- `dataType` (optional): `key`を参照した値のデータ型、指定がなければ文字列リテラル (例 `話数` は int としてソートに使いたいので `http://www.w3.org/2001/XMLSchema#integer`)
+- `objectUriPrefix` (optional): `key`を参照した値に前置して、リテラルではなくURI参照とする (例 `話数` に対して `$BASE_URL/rdfs/episodes/prichan_` を指定してエピソードURI参照とする)
+- `inversePredicate` (optional): `objectUriPrefix` で参照したときに逆参照するときの述語
 
 ### 例: セッティングJSONの `subjectKey`
 

--- a/csv2rdf/csv2rdf.ts
+++ b/csv2rdf/csv2rdf.ts
@@ -19,17 +19,20 @@ interface Setting {
 interface ColumnSetting {
     key: string,
     predicate: string,
-    dataType: string
+    dataType: string,
+    objectUriPrefix: string
 }
 
 const addQuad = (store: N3.N3Store, row:Object, columnSetting:ColumnSetting, setting: Setting) => {
     let objectValue = row[columnSetting.key]
     if (row[columnSetting.key].length == 0) return
-    let object:N3.Literal
+    let object:N3.Term
     if(columnSetting.dataType.length){
         const dataTypeNode = namedNode(columnSetting.dataType)
         object = literal(objectValue, dataTypeNode)
-    }else{
+    } else if (columnSetting.objectUriPrefix && columnSetting.objectUriPrefix.length) {
+        object = namedNode(columnSetting.objectUriPrefix + objectValue)
+    } else {
         object = literal(objectValue)
     }
     store.addQuad(

--- a/csv2rdf/csv2rdf.ts
+++ b/csv2rdf/csv2rdf.ts
@@ -50,11 +50,7 @@ const addQuad = (store: N3.N3Store, row:Object, columnSetting:ColumnSetting, set
         object = literal(objectValue)
     }
 
-    store.addQuad(
-        subject,
-        predicate,
-        object
-    );
+    store.addQuad(subject, predicate, object);
 
 }
 
@@ -93,7 +89,7 @@ const getSettings = async (filePath: string): Promise<Setting> => {
 
 const subjectKey = (row: Object, setting: Setting) => {
     if (setting.subjectKey) {
-        var s = setting.subjectKey.pattern
+        let s = setting.subjectKey.pattern
         setting.subjectKey.keys.forEach((key, index) => {
             s = s.replace("$" + index, row[key])
         })

--- a/csv2rdf/index.ts
+++ b/csv2rdf/index.ts
@@ -25,6 +25,7 @@ import * as rimraf from 'rimraf'
   await csv2rdf.load('../_data/convert-settings/prichan-episodes-setting.json')
   await csv2rdf.load('../_data/convert-settings/series-setting.json')
   await csv2rdf.load('../_data/convert-settings/songs-setting.json')
+  await csv2rdf.load('../_data/convert-settings/pripara-lives-setting.json')
   await csv2rdf.load('../_data/convert-settings/prichan-lives-setting.json')
   await csv2rdf.export('../virtuoso/toLoad/output.ttl')
 })()

--- a/csv2rdf/index.ts
+++ b/csv2rdf/index.ts
@@ -25,5 +25,6 @@ import * as rimraf from 'rimraf'
   await csv2rdf.load('../_data/convert-settings/prichan-episodes-setting.json')
   await csv2rdf.load('../_data/convert-settings/series-setting.json')
   await csv2rdf.load('../_data/convert-settings/songs-setting.json')
+  await csv2rdf.load('../_data/convert-settings/prichan-lives-setting.json')
   await csv2rdf.export('../virtuoso/toLoad/output.ttl')
 })()


### PR DESCRIPTION
related to #35 

* Liveクラスを生成します
* ここでのLiveは，エピソードと曲，をリソース(主語)のURIのキーとして持つようにしました
  * 自然な言葉で「 `プリ☆チャンx話のワンツースウィーツ` は `みらい` が歌って `tt:tt` 開始です」の主語部分が主語になるというイメージ
  * `プリ☆チャンx話の1番目のライブでは` だと n番目カラムがCSV上必須になってしまいデータの用意がしづらいため
  * 同様に開始時刻も必須ではなくoptionalな項目としたい。開始時刻やn番目を知らなくても，空のままでもどんどんデータを入れていってほしい
  * 「 `プリ☆チャンx話のワンツースウィーツをみらいが歌ったライブ` は `tt:tt` 開始です」という主語だとチームまで結合した主語になり，同じチームで同じ曲を同じエピソードで複数回歌った場合に開始時刻を区別できたりするが，稀である(出現が稀 & それを区別したいユースケースが稀) のでそこまで結合を複雑にしたくない
* settings.jsonで， `"subjectKey": {"keys": ["episode", "song"], "pattern": "pripara_$0_$1"}` のように複数キーからのURI生成ができるようになっています
* columns.jsonで， `objectUriPrefix` により1対1でURI参照する目的語がつくれるようになっています
* columns.jsonで， `inversePredicate` により1対1でURI参照した目的語からの逆参照を指定できるようになっています
* LiveのsongとepisodeはそれぞれURI参照にしました
* Liveのteamは参照先がないので現状ではリテラルになっています