### PR TITLE
モバイル端末での表が飛び出す現象への対応

### DIFF
--- a/web/components/SparqlResponseTable.vue
+++ b/web/components/SparqlResponseTable.vue
@@ -39,3 +39,10 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+a,
+span {
+  word-break: break-all;
+}
+</style>


### PR DESCRIPTION
モバイル端末での閲覧時でも，表が画面外に飛び出さなくなりました．

協力ありがとうございました @uneco 