### PR TITLE
Fargateへの移行にあたって，Docker Imageをビルドする形式へ移行

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,10 +4,10 @@ services:
     image: tenforce/virtuoso:1.3.1-virtuoso7.2.2
     volumes:
       - ./virtuoso/scripts:/scripts
-      - ./virtuoso/data:/data
+      - ./virtuoso/data:/data_
     ports:
       - "8890:8890"
-    command: /bin/bash -c "/scripts/virtuoso.sh"
+    command: /bin/bash -c "/scripts/setup.sh && /scripts/start.sh"
   nuxt:
     image: node:11.9.0
     working_dir: "/var/www/app"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,27 @@
 version: '3'
 services:
   sparql:
-    image: tenforce/virtuoso:1.3.1-virtuoso7.2.2
-    volumes:
-      - ./virtuoso/scripts:/scripts
-      - ./virtuoso/data:/data
+    build: ./virtuoso
     ports:
       - "8890:8890"
-    command: /bin/bash -c "/scripts/virtuoso.sh"
   nuxt:
-    image: node:11.9.0
-    working_dir: "/var/www/app"
+    build: ./web
     environment:
       - HOST=0.0.0.0
       - PORT=80
     ports:
       - "80:80"
-    volumes:
-      - ./web:/var/www/app
-    command: bash -c "npm i && npm run build && npm run start"
     depends_on:
       - sparql
       - restapi
   restapi:
-    image: node:11.9.0
-    working_dir: "/var/www/app"
+    build: ./restapi
     ports:
       - "4567:4567"
-    volumes:
-      - ./restapi:/var/www/app
-    command: bash -c "npm i && npm run start"
     depends_on:
       - sparql
+
+networks:
+  external_network:
+  internal_network:
+    internal: true

--- a/restapi/Dockerfile
+++ b/restapi/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:11.9
+
+WORKDIR /var/www/app
+
+ADD ./package.json ./package-lock.json /var/www/app/
+RUN npm ci
+
+ADD . /var/www/app
+
+CMD npm start

--- a/virtuoso/Dockerfile
+++ b/virtuoso/Dockerfile
@@ -1,0 +1,13 @@
+FROM tenforce/virtuoso:1.3.1-virtuoso7.2.2
+
+RUN unlink /data
+RUN ln -s /var/lib/virtuoso/db /data_
+
+ADD ./scripts /scripts
+ADD ./data /data_
+
+RUN /scripts/setup.sh
+
+WORKDIR /data_
+
+CMD /scripts/start.sh

--- a/virtuoso/scripts/setup.sh
+++ b/virtuoso/scripts/setup.sh
@@ -2,7 +2,7 @@
 SETTINGS_DIR=/settings
 mkdir -p $SETTINGS_DIR
 
-cd /data
+cd /data_
 
 mkdir -p dumps
 
@@ -40,7 +40,7 @@ then
     cd backups
     virtuoso-t +restore-backup $BACKUP_PREFIX +configfile /data_/virtuoso.ini
     if [ $? -eq 0 ]; then
-        cd /data
+        cd /data_
         echo "`date +%Y-%m-%dT%H:%M:%S%:z`" > .backup_restored
     else
         exit -1
@@ -75,15 +75,15 @@ then
     echo "`date +%Y-%m-%dT%H:%M:%S%:z`" > .data_loaded
 fi
 
-crudini --set virtuoso.ini HTTPServer ServerPort ${VIRT_HTTPServer_ServerPort:-$original_port}
-
 # Enable Federated
-touch /enable-federated-query.sql
-echo "grant select on \"DB.DBA.SPARQL_SINV_2\" to \"SPARQL\";" >> /enable-federated-query.sql
-echo "grant execute on \"DB.DBA.SPARQL_SINV_IMP\" to \"SPARQL\";" >> /enable-federated-query.sql
-virtuoso-t +wait && isql-v -U dba -P dba < /enable-federated-query.sql
-kill "$(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')"
-echo "`date +%Y-%m-%dT%H:%M:%S%:z`" >  .enable_federated
+if [ ! -f ".enable_federated" ];
+then
+  touch /enable-federated-query.sql
+  echo "grant select on \"DB.DBA.SPARQL_SINV_2\" to \"SPARQL\";" >> /enable-federated-query.sql
+  echo "grant execute on \"DB.DBA.SPARQL_SINV_IMP\" to \"SPARQL\";" >> /enable-federated-query.sql
+  virtuoso-t +wait && isql-v -U dba -P dba < /enable-federated-query.sql
+  kill "$(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')"
+  echo "`date +%Y-%m-%dT%H:%M:%S%:z`" >  .enable_federated
+fi
 
-
-exec virtuoso-t +wait +foreground
+crudini --set virtuoso.ini HTTPServer ServerPort ${VIRT_HTTPServer_ServerPort:-$original_port}

--- a/virtuoso/scripts/start.sh
+++ b/virtuoso/scripts/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /data
+exec virtuoso-t +wait +foreground

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:11.9
+
+WORKDIR /var/www/app
+
+ADD ./package.json ./package-lock.json /var/www/app/
+RUN npm ci
+
+ADD . /var/www/app
+RUN npm run build
+
+CMD npm start

--- a/web/nuxt.config.js
+++ b/web/nuxt.config.js
@@ -25,7 +25,6 @@ export default {
    ** Global CSS
    */
   css: [
-    // lib css
     'codemirror/lib/codemirror.css',
     // merge css
     'codemirror/addon/merge/merge.css',
@@ -36,9 +35,7 @@ export default {
   /*
    ** Plugins to load before mounting the App
    */
-  plugins: [
-    { src: '~plugins/nuxt-codemirror-plugin.js', ssr: false }
-  ],
+  plugins: [{ src: '~plugins/nuxt-codemirror-plugin.js', ssr: false }],
   // some nuxt config...
 
   /*
@@ -49,9 +46,7 @@ export default {
     '@nuxtjs/axios',
     // Doc: https://buefy.github.io/#/documentation
     'nuxt-buefy',
-    [ '@nuxtjs/proxy', {
-      pathRewrite: {'^/api' : 'http://restapi:4567'}
-    }]
+    '@nuxtjs/proxy'
   ],
   /*
    ** Axios module configuration
@@ -62,7 +57,10 @@ export default {
 
   proxy: {
     '/sparql': 'http://sparql:8890/sparql',
-    '/api': 'http://restapi:4567'
+    '/api': {
+      target: 'http://restapi:4567',
+      pathRewrite: { '^/api': '/' }
+    }
   },
 
   /*
@@ -80,8 +78,8 @@ export default {
           test: /\.(js|vue)$/,
           loader: 'eslint-loader',
           exclude: /(node_modules)/,
-          options : {
-            fix : true
+          options: {
+            fix: true
           }
         })
       }


### PR DESCRIPTION
relate #143 

- Fargate は voleme マウントが使えない．つまりは，現在の方法でソースコードを docker-compose に流し込むことは不可能．
- 手元(あるいはCI)で，ソースコードを包括したDocker Image をビルドし，それをAWSにアップロードする必要がある
- 現在は voleme マウント を用いた構成であるため， `docker-compose build` で Docker Image のビルドを行うように変更した
- `docker-compose.dev.yml` に関しては volume を用いた形式を続行

メモ
- `tenforce/virtuoso` Image が強制的に `/data` つまりはDBの中身を VOLUME に設定してくるため，Build した際のデータが， `docker-compose up` による立ち上げ時に吹っ飛ぶという事故があった(そもそもこの image は volume マウントすることを前提にして設計されているようだ)． ので， `/data_` に DB の内容を退避することで事なきを得た．
- サービス名によるコンテナ間の名前解決は Fargate ではダメらしい．早急に手を打たねば．