### PR TITLE
name_kanaをひらがなにする

### DIFF
--- a/_data/character/prichan-characters.csv
+++ b/_data/character/prichan-characters.csv
@@ -5,7 +5,7 @@ aoba_rinka,青葉 りんか,あおば りんか,厚木那奈美,1月25日,A型,�
 akagi_anna,赤城 あんな,あかぎ あんな,芹澤優,7月6日,O型,紅茶,Dolly Waltz,ラブリー,147
 midorikawa_sara,緑川 さら,みどりかわ さら,若井友希,6月9日,O型,ステーキ,Romance Beat,クール,163
 shidou_meru,紫藤 める,しどう める,森嶋優花,4月23日,AB型,ドーナツ,Universe Queen,クール,
-shiratori_anjyu,白鳥 アンジュ,しらとり アンジュ,三森すずこ,11月11日,A型,,Precious muse,プレミアム,
+shiratori_anjyu,白鳥 アンジュ,しらとり あんじゅ,三森すずこ,11月11日,A型,,Precious muse,プレミアム,
 nanahoshi_aira,七星 あいら,ななほし あいら,阿澄佳奈,,,,,,
 kanamori_maria,金森 まりあ,かなもり まりあ,茜屋日海夏,5月9日,,アイスクリーム,Cutie Happiness,ラブリー,
 kurokawa_suzu,黒川 すず,くろかわ すず,徳井青空,12月6日,,モナカ,Dance & street,クール,

--- a/_data/character/pripara-characters.csv
+++ b/_data/character/pripara-characters.csv
@@ -2,22 +2,22 @@ key,name,name_kana,cv,birthday,blood_type,favorite_food,brand,charm
 manaka_laala,真中 らぁら,まなか らぁら,茜屋日海夏,11月20日,O型,ピザ、駄菓子,Twinkle Ribbon（トゥインクルリボン）,ラブリー
 minami_mirei,南 みれぃ,みなみ みれぃ,芹澤優,10月1日,A型,スイーツ全般,Candy Alamode（キャンディアラモード）,ポップ
 hojo_sophie,北条 そふぃ,ほうじょう そふぃ,久保田未夢,7月30日,AB型,梅干し,Holic Trick（ホリックトリック）,クール
-todo_shion,東堂 シオン,とうどう シオン,山北早紀,1月5日,B型,大福,Baby Monster（ベイビーモンスター）,クール
+todo_shion,東堂 シオン,とうどう しおん,山北早紀,1月5日,B型,大福,Baby Monster（ベイビーモンスター）,クール
 dorothy_west,ドロシー・ウェスト,どろしー うぇすと,澁谷梓希,2月5日,A型,もんじゃ焼き,Fortune Party（フォーチュンパーティ）,ポップ
 leona_west,レオナ・ウェスト,れおな うぇすと,若井友希,2月5日,A型,いちごパフェ,Fortune Party（フォーチュンパーティ）,ポップ
 kurosu_aroma,黒須 あろま,くろす あろま,牧野由依,6月6日,A型,カレーうどん,Holic Trick classic（ホリックトリック クラシック）、LOVE DEVI（ラブデビ）,クール
 shiratama_mikan,白玉 みかん,しらたま みかん,渡部優衣,10月4日,B型,プリン、中華まん,Silky Heart（シルキーハート）、LOVE DEVI（ラブデビ）,ラブリー
-gaaruru,ガァルル,,真田アサミ,4月17日,,アーモンドクッキー,Marionette Mu（マリオネットミュー）、LOVE DEVI（ラブデビ）,ラブリー
+gaaruru,ガァルル,がぁるる,真田アサミ,4月17日,,アーモンドクッキー,Marionette Mu（マリオネットミュー）、LOVE DEVI（ラブデビ）,ラブリー
 shikyoin_hibiki,紫京院 ひびき,しきょういん ひびき,斎賀みつき,3月27日,B型,ガトーショコラ,Brilliant Prince（ブリリアントプリンス）,セレブ
-falulu,ファルル,,赤﨑千夏,3月21日,,牛乳,Marionette Mu（マリオネットミュー）,ラブリー
+falulu,ファルル,ふぁるる,赤﨑千夏,3月21日,,牛乳,Marionette Mu（マリオネットミュー）,ラブリー
 midorikaze_fuwari,緑風 ふわり,みどりかぜ ふわり,佐藤あずさ,8月11日,O型,お寿司,Coco Flower（ココフラワー）,ナチュラル
 manaka_non,真中 のん,まなか のん,田中美海,9月6日,A型,パスタ,Twinkle Ribbon Sweet（トゥインクルリボンスウィート）,
 tsukikawa_chiri,月川 ちり,つきかわ ちり,大森日雅,11月15日,AB型,栗きんとん,Dear Crown（ディアクラウン）,
-taiyo_pepper,太陽 ペッパー,たいよう ペッパー,山下七海,2月9日,O型,焼肉,Sunny Zoo（サニーズー）,
+taiyo_pepper,太陽 ペッパー,たいよう ぺっぱー,山下七海,2月9日,O型,焼肉,Sunny Zoo（サニーズー）,
 junon,じゅのん,じゅのん,田中美海,,,,,
 pinon,ぴのん,ぴのん,田中美海,,,,,
 kanon,かのん,かのん,田中美海,,,,,
-hojo_cosmo,北条 コスモ,ほうじょう コスモ,山本希望,9月12日,AB型,しょうゆラーメン、ドライマンゴー、玉子,PrismStone（プリズムストーン）,クール/プレミアム
+hojo_cosmo,北条 コスモ,ほうじょう こすも,山本希望,9月12日,AB型,しょうゆラーメン、ドライマンゴー、玉子,PrismStone（プリズムストーン）,クール/プレミアム
 kiki_ajimi,黄木 あじみ,きき あじみ,上田麗奈,11月3日,A型,チキンライス,Candy Alamode more（キャンディアラモードモア）,ポップ
 nabesima_chanko,鍋島 ちゃん子,なべしま ちゃんこ,赤﨑千夏,,,,,クール
 jewlie,ジュリィ,じゅりぃ,上田麗奈,,,桃ジュース、綿菓子,,


### PR DESCRIPTION
closes #214 

name_kanaがカタカナだった箇所をひらがなにしました。例えばname_kanaをひらがなで検索したいときに，ひらがなカタカナ無視検索を使わなくても，ひらがなのみで検索できるようになります。

空欄だった箇所もひらがなで埋めました。