### PR TITLE
Songsにname_kanaを追加

### DIFF
--- a/_data/song/songs-columns.csv
+++ b/_data/song/songs-columns.csv
@@ -1,2 +1,3 @@
 key,predicate,dataType
 name,name,
+name_kana,name_kana,

--- a/_data/song/songs.csv
+++ b/_data/song/songs.csv
@@ -1,107 +1,107 @@
-key,name
-make_it,Make it!
-taiyo_no_flare_serbet,太陽のflare sherbet
-marble_make_up_a_ha_ha,ま～ぶるMake up a-ha-ha!
-pretty_prism_paradise,Pretty Prism Paradise!!!
-no_d_and_d_code,No D&D code
-happy_pa_lucky,HAPPYぱLUCKY
-change_my_world,CHANGE! MY WORLD
-realize,Realize!
-zero_week_old,0（ゼロ）-week-old
-kimi_100_percent_jinse,君100%人生
-love_friend_style,Love friend style
-dream_parade,ドリームパレード
-debi_en_reversible_ring,でび&えん☆Reversible-Ring
-taiyo_no_flare_serbet_sakura_shower_ver,太陽のflare sherbet サクラシャワーver.
-lucky_surprise_birthday,ラッキー！サプライズ☆バースデイ
-konouta_tomareihi,コノウタトマレイヒ
-tondemo_summer_adventure,トンでもSUMMER ADVENTURE
-love_week_old,0（ラブ）-week-old
-zettai_seimei_final_show_jo,絶対生命 final show女
-panic_labyrinth,パニックラビリンス
-rainbow_melody,レインボウ・メロディー♪
-omu_omelet,オムオムライス
-papipupe_police,ぱぴぷぺ☆POLICE!
-thank_you_birthday,Thankyou♥Birthday
-jun_amore_ai,純・アモーレ・愛
-what_a_wonder_pri_world,ホワット・ア・ワンダプリ・ワールド!!
-goin_on,Goin'on
-virtual_idol,ヴァーチャデリアイドル♥
-pritto_perfect,ぷりっとぱ～ふぇくと
-twin_mirror_compact,Twin mirror♥compact
-around_the_pripara_land,アラウンド・ザ・プリパランド！
-triangle_star,トライアングル・スター
-ready_smile,Ready Smile!!
-pripara_dancing,プリパラ☆ダンシング!!!
-charisma_to_girl_yeah,かりすま～とGIRL☆Yeah!
-run_for_jumping,ラン♪ for ジャンピン!
-brand_new_dreamer,Brand New Dreamer
-amazing_castle,アメイジング・キャッスル
-just_my_chance_call,Just My Chance Call
-mon_chouchou,Mon chouchou
-growin_jewel,Growin‘ Jewel!
-girls_fantasy,Girl's Fantasy
-sugarless_friend,シュガーレス×フレンド
-idle_wo_torimodose,愛ドルを取り戻せ！
-i_friend_you,組曲フォーエバー☆フレンズ ～第一楽章～ I FRIEND YOU!!
-love_is_friend,組曲フォーエバー☆フレンズ ～第二楽章～ LOVE IS FRIEND
-memories_medley,組曲フォーエバー☆フレンズ ～インターリュード～ メモリーズ・メドレー
-my_friend_dear_friend,"組曲フォーエバー☆フレンズ ～第三楽章～ My Friend, Dear Friend"
-we_are_the_friends,組曲フォーエバー☆フレンズ ～第四楽章～ ウィー・アー・ザ・フレンズ!
-jumpin_dancin,Jumpin'! Dancin'!
-miracle_paradise,ミラクル☆パラダイス
-kiraki_runway,キラキランウェイ☆
-i_just_wana_be_with_you,I Just Wanna Be With You ~仮想(ヴァーチャル)と真実(リアル)の狭間で~
-idol_kinryoku_lesson_go,アイドルキンリョク♥Lesson GO!
-mune_kyun_love_song,胸キュンLove Song
-bright_fantasy,ブライトファンタジー
-love_trooper,LOVE TROOPER
-shining_star,Shining Star
-ticktock_magical_idol_time,チクタク・Magicaる・アイドルタイム!
-gira_galactic_tightrope,Giraギャラティック・タイトロープ
-make_it_remake_it_remix,Make it! ~Remake It☆Remix~
-red_flash_fevolution,Red Flash Revolution
-brand_new_happiness!,ブランニュー・ハピネス！
-accha_koccha_game,あっちゃこっちゃゲーム
-gost_coaster,GOスト♭コースター
-neo_dimension_go,Neo Dimension Go!!
-kaida_sensin_kakkin_buddy,快打洗心♡カッキンBUDDY
-miss_prionaire,Miss.プリオネア
-believe_my_dream,Believe My DREAM!!
-sunshine_bell,サンシャイン・ベル!
-starlight_carnival,すた～らいとカーニバル☆
-dear_my_future_miraino_jibunhe,Dear My Future　～未来の自分へ～
-ring_ring_garafaland,リンリン♪がぁらふぁらんど
-get_over_dress_code,Get Over Dress-code
-just_be_yourself,Just be yourself
-idol_time,アイドル:タイム!!
-saijokyu_paradox,最上級ぱらどっくす
-heartful_dream,ハートフル♡ドリーム
-memorial,Memorial
-welcome_to_dream,WELCOME TO DREAM
-kiratto_start,キラッとスタート
-go_up_stardum,Go! Up! スターダム！
-never_ending,never-ending!!
-diamond_smile,ダイヤモンドスマイル
-pretty_channel,プリティー☆チャンネル
-kira_kira_holography,KIRA KIRA ホログラム
-shining_flower,SHINING FLOWER
-janken_kiratto_prichan,じゃんけんキラッと！プリ☆チャン
-ready_action,レディー・アクション！
-one_two_sweets,ワン・ツー・スウィーツ
-suki_suki_sensor,スキスキセンサー
-play_sound,Play Sound☆
-kirari_kakusei_reincarnation,キラリ覚醒☆リインカーネーション
-super_cutie_super_girl,SUPER CUTIE SUPER GIRL
-cometic_silhouette,COMETIC SILHOUETTE
-fortune_carat,フォーチュン・カラット
-oshama_tricks_no_uta,おしゃまトリックスの歌
-otome_attention_please,乙女アテンションプリーズ
-netemo_sametemo_dreamin_girl,寝ても覚めてもDREAMIN' GIRL
-dream_goes_on,Dream Goes On
-perfect_finale,パーフェクト・フィナーレ
-tokimeki_heart_jewel,TOKIMEKIハート・ジュエル♪
-shiawasei_kawaii_sanka,シアワ星かわいい賛歌
-yumeiro_energy,夢色エナジー
-you_may_dream,You May Dream
-eien_no_bigaku,1/1000永遠の美学
+key,name,name_kana
+make_it,Make it!,めいくいっと
+taiyo_no_flare_serbet,太陽のflare sherbet,たいようのふれあしゃーべっと
+marble_make_up_a_ha_ha,ま～ぶるMake up a-ha-ha!,まーぶるめいくあっぷあはは
+pretty_prism_paradise,Pretty Prism Paradise!!!,ぷりてぃーぷりずむぱらだいす
+no_d_and_d_code,No D&D code,のーでぃーあんどでぃーこーど
+happy_pa_lucky,HAPPYぱLUCKY,はっぴーぱらっきー
+change_my_world,CHANGE! MY WORLD,ちぇんじまいわーるど
+realize,Realize!,りあらいず
+zero_week_old,0（ゼロ）-week-old,ぜろうぃーくおーるど
+kimi_100_percent_jinse,君100%人生,きみひゃくぱーせんとじんせい
+love_friend_style,Love friend style,らぶふれんどすたいる
+dream_parade,ドリームパレード,どりーむぱれーど
+debi_en_reversible_ring,でび&えん☆Reversible-Ring,でびえんりばーしぶりんぐ
+taiyo_no_flare_serbet_sakura_shower_ver,太陽のflare sherbet サクラシャワーver.,たいようのふれあしゃーべっと さくらしゃわーばーじょん
+lucky_surprise_birthday,ラッキー！サプライズ☆バースデイ,らっきーさぷらいずばーすでい
+konouta_tomareihi,コノウタトマレイヒ,このうたとまれいひ
+tondemo_summer_adventure,トンでもSUMMER ADVENTURE,とんでもさまーあどべんちゃー
+love_week_old,0（ラブ）-week-old,らぶうぃーくおーるど
+zettai_seimei_final_show_jo,絶対生命 final show女,ぜったいせいめいふぁいなるしょうじょ
+panic_labyrinth,パニックラビリンス,ぱにっくらびりんす
+rainbow_melody,レインボウ・メロディー♪,れいんぼうめろでぃー
+omu_omelet,オムオムライス,おむおむらいす
+papipupe_police,ぱぴぷぺ☆POLICE!,ぱぴぷぺぽりす
+thank_you_birthday,Thankyou♥Birthday,さんきゅーばーすでい
+jun_amore_ai,純・アモーレ・愛,ぴゅあもーれあい
+what_a_wonder_pri_world,ホワット・ア・ワンダプリ・ワールド!!,ほわっとあわんだぷりわーるど
+goin_on,Goin'on,ごーいんおん
+virtual_idol,ヴァーチャデリアイドル♥,ばーちゃでりあいどる
+pritto_perfect,ぷりっとぱ～ふぇくと,ぷりっとぱーふぇくと
+twin_mirror_compact,Twin mirror♥compact,ついんみらーこんぱくと
+around_the_pripara_land,アラウンド・ザ・プリパランド！,あらうんどざぷりぱらんど
+triangle_star,トライアングル・スター,とらいあんぐるすたー
+ready_smile,Ready Smile!!,れでぃーすまいる
+pripara_dancing,プリパラ☆ダンシング!!!,ぷりぱらだんしんぐ
+charisma_to_girl_yeah,かりすま～とGIRL☆Yeah!,かりすまーとがーるいぇい
+run_for_jumping,ラン♪ for ジャンピン!,らんふぉーじゃんぴん
+brand_new_dreamer,Brand New Dreamer,ぶらんにゅーどりーまー
+amazing_castle,アメイジング・キャッスル,あめいじんぐきゃっする
+just_my_chance_call,Just My Chance Call,じゃすとまいちゃんすこーる
+mon_chouchou,Mon chouchou,もんしゅしゅ
+growin_jewel,Growin‘ Jewel!,ぐろーいんじゅえる
+girls_fantasy,Girl's Fantasy,がーるずふぁんたじー
+sugarless_friend,シュガーレス×フレンド,しゅがーれすふれんど
+idle_wo_torimodose,愛ドルを取り戻せ！,あいどるをとりもどせ
+i_friend_you,組曲フォーエバー☆フレンズ ～第一楽章～ I FRIEND YOU!!,くみきょくふぉーえばーふれんず だいいちがくしょう あいふれんどゆー
+love_is_friend,組曲フォーエバー☆フレンズ ～第二楽章～ LOVE IS FRIEND,くみきょくふぉーえばーふれんず だいにがくしょう らぶいずふれんど
+memories_medley,組曲フォーエバー☆フレンズ ～インターリュード～ メモリーズ・メドレー,くみきょくふぉーえばーふれんず いんたーりゅーど めもりーずめどれー
+my_friend_dear_friend,"組曲フォーエバー☆フレンズ ～第三楽章～ My Friend, Dear Friend",くみきょくふぉーえばーふれんず だいさんがくしょう まいふれんどでぃあふれんど
+we_are_the_friends,組曲フォーエバー☆フレンズ ～第四楽章～ ウィー・アー・ザ・フレンズ!,くみきょくふぉーえばーふれんず だいよんがくしょう うぃーあーざふれんず
+jumpin_dancin,Jumpin'! Dancin'!,じゃんぴんだんしん
+miracle_paradise,ミラクル☆パラダイス,みらくるぱらだいす
+kiraki_runway,キラキランウェイ☆,きらきらんうぇい
+i_just_wana_be_with_you,I Just Wanna Be With You ~仮想(ヴァーチャル)と真実(リアル)の狭間で~,あいじゃすとわなびーうぃずゆー ばーちゃるとりあるのはざまで
+idol_kinryoku_lesson_go,アイドルキンリョク♥Lesson GO!,あいどるきんりょくれっすんごー
+mune_kyun_love_song,胸キュンLove Song,むねきゅんらぶそんぐ
+bright_fantasy,ブライトファンタジー,ぶらいとふぁんたじー
+love_trooper,LOVE TROOPER,らぶとるーぱー
+shining_star,Shining Star,しゃいにんぐすたー
+ticktock_magical_idol_time,チクタク・Magicaる・アイドルタイム!,ちくたくまじかるあいどるたいむ
+gira_galactic_tightrope,Giraギャラティック・タイトロープ,ぎらぎゃらくてぃっくたいとろーぷ
+make_it_remake_it_remix,Make it! ~Remake It☆Remix~,めいくいっとりめいくいっとりみっくす
+red_flash_fevolution,Red Flash Revolution,れっどふらっしゅれぼりゅーしょん
+brand_new_happiness!,ブランニュー・ハピネス！,ぶらんにゅーはぴねす
+accha_koccha_game,あっちゃこっちゃゲーム,あっちゃこっちゃげーむ
+gost_coaster,GOスト♭コースター,ごーすとこーすたー
+neo_dimension_go,Neo Dimension Go!!,ねおでぃめんしょんごー
+kaida_sensin_kakkin_buddy,快打洗心♡カッキンBUDDY,かいだせんしんかっきんばでぃー
+miss_prionaire,Miss.プリオネア,みすぷりおねあ
+believe_my_dream,Believe My DREAM!!,びりーぶまいどりーむ
+sunshine_bell,サンシャイン・ベル!,さんしゃいんべる
+starlight_carnival,すた～らいとカーニバル☆,すたーらいとかーにばる
+dear_my_future_miraino_jibunhe,Dear My Future　～未来の自分へ～,でぃあまいふゅーちゃー みらいのじぶんへ
+ring_ring_garafaland,リンリン♪がぁらふぁらんど,りんりんがぁらふぁらんど
+get_over_dress_code,Get Over Dress-code,げっとおーばーどれすこーど
+just_be_yourself,Just be yourself,じゃすとびーゆあせるふ
+idol_time,アイドル:タイム!!,あいどるたいむ
+saijokyu_paradox,最上級ぱらどっくす,さいじょうきゅうぱらどっくす
+heartful_dream,ハートフル♡ドリーム,はーとふるどりーむ
+memorial,Memorial,めもりある
+welcome_to_dream,WELCOME TO DREAM,うぇるかむとぅどりーむ
+kiratto_start,キラッとスタート,きらっとすたーと
+go_up_stardum,Go! Up! スターダム！,ごーあっぷすたーだむ
+never_ending,never-ending!!,ねばーえんでぃんぐ
+diamond_smile,ダイヤモンドスマイル,だいやもんどすまいる
+pretty_channel,プリティー☆チャンネル,ぷりてぃーちゃんねる
+kira_kira_holography,KIRA KIRA ホログラム,きらきらほろぐらむ
+shining_flower,SHINING FLOWER,しゃいにんぐふらわー
+janken_kiratto_prichan,じゃんけんキラッと！プリ☆チャン,じゃんけんきらっとぷりちゃん
+ready_action,レディー・アクション！,れでぃーあくしょん
+one_two_sweets,ワン・ツー・スウィーツ,わんつーすうぃーつ
+suki_suki_sensor,スキスキセンサー,すきすきせんさー
+play_sound,Play Sound☆,ぷれいさうんど
+kirari_kakusei_reincarnation,キラリ覚醒☆リインカーネーション,きらりかくせいりいんかーねーしょん
+super_cutie_super_girl,SUPER CUTIE SUPER GIRL,すーぱーきゅーてぃーすーぱーがーる
+cometic_silhouette,COMETIC SILHOUETTE,こめてぃっくしるえっと
+fortune_carat,フォーチュン・カラット,ふぉーちゅんからっと
+oshama_tricks_no_uta,おしゃまトリックスの歌,おしゃまとりっくすのうた
+otome_attention_please,乙女アテンションプリーズ,おとめあてんしょんぷりーず
+netemo_sametemo_dreamin_girl,寝ても覚めてもDREAMIN' GIRL,ねてもさめてもどりーみんがーる
+dream_goes_on,Dream Goes On,どりーむごーずおん
+perfect_finale,パーフェクト・フィナーレ,ぱーふぇくとふぃなーれ
+tokimeki_heart_jewel,TOKIMEKIハート・ジュエル♪,ときめきはーとじゅえる
+shiawasei_kawaii_sanka,シアワ星かわいい賛歌,しあわせいかわいいさんか
+yumeiro_energy,夢色エナジー,ゆめいろえなじー
+you_may_dream,You May Dream,ゆーめいどりーむ
+eien_no_bigaku,1/1000永遠の美学,せんぶんのいちえいえんのびがく


### PR DESCRIPTION
曲名のかな表記を追加しました。

かな表記の正しいソースを見つけられていないので感覚的にかな化したところがほとんどです。ソースのある情報(ゲーム・アニメ・ライブ内での読み上げとか)があれば都度修正していければよいかと思います。

* 読まない(であろう)記号は省いています
* 曲名として区切りが読みとれるところにはスペースを置いています。「サクラシャワーver.」の前とか「だいいちがくしょう」の前後とか
* 長音系は「ー」にしています
* ヴァーチャルの「ゔぁ」は読み仮名としてあまり無いかもしれないので「ば」にしています