### PR TITLE
prism:, rdf:, rdfs:のprefixと主語リンクのホストまでをWebでは省略表示する

### DIFF
--- a/web/components/SparqlResponseTable.vue
+++ b/web/components/SparqlResponseTable.vue
@@ -11,7 +11,12 @@
           :href="
             props.row[col].value.replace('https://prismdb.takanakahiko.me', '')
           "
-        >{{ props.row[col].value }}</a>
+        >{{ props.row[col].value
+          .replace('https://prismdb.takanakahiko.me/prism-schema.ttl#', 'prism:')
+          .replace('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'rdf:')
+          .replace('http://www.w3.org/2000/01/rdf-schema#', 'rdfs:')
+          .replace('https://prismdb.takanakahiko.me', '')
+        }}</a>
         <span v-else>{{ props.row[col].value }}</span>
       </b-table-column>
     </template>


### PR DESCRIPTION
closes #89 (たぶん)

リレーション増えてきたので、Webで表示するときにコンパクトにしようかと。(vueの書き方よく分かっていないです)

`prism:` がPrismDBの独自prefixなのでそこはその名前で良いとして、 `rdf:` `rdfs:` は一般のものなので他の名前でprefix参照することもあるかもしれませんが、 RDF Schema 1.1 https://www.w3.org/TR/rdf-schema/ ではこれらのprefixを使っているし、virtuosoのpredefined namespacesにもこれらの名前で存在しているので、採用しました。

<img width="384" alt="image" src="https://user-images.githubusercontent.com/11156/71656942-db81c480-2d80-11ea-82ea-470c4e795a74.png">
