### PR TITLE
forkされたリポジトリからのPRの時にエラーにならないようにした

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -20,16 +20,17 @@ on:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:
           app_id: ${{ secrets.GH_APPS_ID }}
           private_key: ${{ secrets.GH_APPS_PRIVATE_KEY }}
+        continue-on-error: true
       - name: automerge
         uses: "pascalgn/automerge-action@f81beb99aef41bb55ad072857d43073fba833a98"
         env:
           GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           MERGE_LABELS: "automerge"
           MERGE_REMOVE_LABELS: "automerge"
+        continue-on-error: true


### PR DESCRIPTION
https://github.com/prickathon/prismdb/pull/290/checks?check_run_id=980947008 がエラーになっている件の対応

`jobs.<job_id>.continue-on-error` が効いていないように見えるので `jobs.<job_id>.steps.continue-on-error` を使うようにしました。