### PR TITLE
ジョブ終了時にSlackに通知を飛ばすようにした

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -34,3 +34,12 @@ jobs:
           MERGE_LABELS: "automerge"
           MERGE_REMOVE_LABELS: "automerge"
         continue-on-error: true
+      - name: Slack Notification
+        uses: lazy-actions/slatify@master
+        if: always()
+        continue-on-error: true
+        with:
+          job_name: '*automerge*'
+          type: ${{ job.status }}
+          url: ${{ secrets.SLACK_WEBHOOK }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,3 +37,13 @@ jobs:
 
       - name: Build a docker image
         run: docker build ${{ matrix.SERVICE_NAME }} $BUILD_ARGS
+
+      - name: Slack Notification
+        uses: lazy-actions/slatify@master
+        if: always()
+        continue-on-error: true
+        with:
+          job_name:  ${{ format('*delivery* ({0})', matrix.SERVICE_NAME) }}
+          type: ${{ job.status }}
+          url: ${{ secrets.SLACK_WEBHOOK }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -65,3 +65,13 @@ jobs:
               --allow-unauthenticated \
               --quiet \
               $DEPLOY_ARGS
+
+      - name: Slack Notification
+        uses: lazy-actions/slatify@master
+        if: always()
+        continue-on-error: true
+        with:
+          job_name:  ${{ format('*delivery* ({0})', matrix.SERVICE_NAME) }}
+          type: ${{ job.status }}
+          url: ${{ secrets.SLACK_WEBHOOK }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rdflint.yml
+++ b/.github/workflows/rdflint.yml
@@ -16,3 +16,12 @@ jobs:
           npm ci
           BASE_URL=https://prismdb.takanakahiko.me npm start
       - run: rdflint -config virtuoso/rdflint-config.yml -targetdir virtuoso/data/toLoad
+      - name: Slack Notification
+        uses: lazy-actions/slatify@master
+        if: always()
+        continue-on-error: true
+        with:
+          job_name: '*rdflint*'
+          type: ${{ job.status }}
+          url: ${{ secrets.SLACK_WEBHOOK }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/re-generate.yml
+++ b/.github/workflows/re-generate.yml
@@ -28,3 +28,12 @@ jobs:
           お店情報の自動アップデートです！ #274
         labels: |
           automerge
+    - name: Slack Notification
+      uses: lazy-actions/slatify@master
+      if: "! success()" # cronで実行されるので失敗時のみ通知する
+      continue-on-error: true
+      with:
+        job_name: '*re-generate*'
+        type: ${{ job.status }}
+        url: ${{ secrets.SLACK_WEBHOOK }}
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#308 で話した件です。

* 全てのジョブの終了時に https://github.com/marketplace/actions/slatify でSlack通知飛ばすようにしています。
* 基本的には成功と失敗の両方通知ですが、`re-generate` のみ失敗時のみ通知飛ばすようにしています。（cronで実行時に毎回通知飛ぶのもノイズになりそうなので）

# お願い
マージする前にSecretsの `SLACK_WEBHOOK` にslackのwebhookを入れて下さい

Close #308