### PR TITLE
Migrate to new setup-gcloud

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -30,7 +30,7 @@ jobs:
           BASE_URL=https://prismdb.takanakahiko.me npm start
 
       - name: GCP Authenticate
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: '306.0.0'
           service_account_key: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
[GitHub Actionsのログ](https://github.com/prickathon/prismdb/runs/1671974553?check_suite_focus=true
) に

```
Warning: Thank you for using setup-gcloud Action. GoogleCloudPlatform/github-actions/setup-gcloud has been deprecated, please switch to google-github-actions/setup-gcloud.
```

と出ているため新しいActionに移行しました。

c.f. https://github.com/google-github-actions/setup-gcloud/tree/master/setup-gcloud