### PR TITLE
Refactor: Set step name

### DIFF
--- a/.github/workflows/re-generate.yml
+++ b/.github/workflows/re-generate.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - working-directory: csv2rdf
+      name: update shops
       run: |
         npm ci
         $(npm bin)/ts-node tools/update-shops-prichan.ts


### PR DESCRIPTION
GitHub Actionsの画面を見て表示されているstep名から実際に実行される内容が分かりづらかったので `name` をつけて分かりやすくしました。

![image](https://user-images.githubusercontent.com/608755/135192603-2893f08d-2789-44df-a5b1-5575fdb35bfe.png)

![image](https://user-images.githubusercontent.com/608755/135192588-3d7bf1b8-99e8-404d-a8c1-47559a48c83c.png)

c.f. https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsname