### PR TITLE
店舗情報が無い時にcsvに「該当する店舗がありません。」が出力されないようにした

### DIFF
--- a/_data/shop/pripara_山形県.csv
+++ b/_data/shop/pripara_山形県.csv
@@ -1,2 +1,1 @@
 series,prefecture,name,address
-pripara,山形県,,該当する店舗がありません。

--- a/_data/shop/pripara_福島県.csv
+++ b/_data/shop/pripara_福島県.csv
@@ -1,2 +1,1 @@
 series,prefecture,name,address
-pripara,福島県,,該当する店舗がありません。

--- a/csv2rdf/tools/update-shops-prichan.ts
+++ b/csv2rdf/tools/update-shops-prichan.ts
@@ -16,6 +16,8 @@ const fetchShop = async (prefName: string) => {
       name,
       address
     }
+  }).filter((shop) => {
+    return shop.name.length > 0 && shop.address.length > 0;
   })
   return ret
 }

--- a/csv2rdf/tools/update-shops-primagi.ts
+++ b/csv2rdf/tools/update-shops-primagi.ts
@@ -15,6 +15,8 @@ const fetchShop = async (prefId: string, prefName: string) => {
       name: value["Name"],
       address: address,
     }
+  }).filter((shop) => {
+    return shop.name.length > 0 && shop.address.length > 0;
   })
   return ret
 }

--- a/csv2rdf/tools/update-shops-pripara.ts
+++ b/csv2rdf/tools/update-shops-pripara.ts
@@ -16,6 +16,8 @@ const fetchShop = async (prefName: string) => {
       name,
       address
     }
+  }).filter((shop) => {
+    return shop.name.length > 0 && shop.address.length > 0;
   })
   return ret
 }


### PR DESCRIPTION
#425 で下記のようなcsvが生成されていたため、nameやaddressが欠けていた場合にはスクリプト側で出力しないようにしました。

* https://github.com/prickathon/prismdb/blob/747f9c088efab5e4064039f313146e4f1a7b24cf/_data/shop/pripara_%E5%B1%B1%E5%BD%A2%E7%9C%8C.csv
* https://github.com/prickathon/prismdb/blob/747f9c088efab5e4064039f313146e4f1a7b24cf/_data/shop/pripara_%E7%A6%8F%E5%B3%B6%E7%9C%8C.csv