### PR TITLE
Migrate to setup-gcloud@v0

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -30,7 +30,7 @@ jobs:
           BASE_URL=https://prismdb.takanakahiko.me npm start
 
       - name: GCP Authenticate
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '306.0.0'
           service_account_key: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
`google-github-actions/setup-gcloud` のmasterブランチを使ってるとCIでエラーになるようになってたのでv0を使うようにしました。

c.f. https://github.com/google-github-actions/setup-gcloud/issues/539