### PR TITLE
regenerateでエラーが出るのを修正

### DIFF
--- a/csv2rdf/tools/update-shops-primagi.ts
+++ b/csv2rdf/tools/update-shops-primagi.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as csv from "async-csv";
 import * as cheerio from 'cheerio'
+import * as https from 'https'
 import axios from 'axios'
 
 const fetchShop = async (prefId: string, prefName: string) => {
@@ -24,7 +25,8 @@ const fetchShop = async (prefId: string, prefName: string) => {
 }
 
 const getPrefs = async () => {
-  const { data } = await axios.get('https://primagi.jp/shop/')
+  const httpsAgent = new https.Agent({ rejectUnauthorized: false })
+  const { data } = await axios.get('https://primagi.jp/shop/', { httpsAgent })
   const $ = cheerio.load(data)
   return $('.prefectures .prefectures_item a').toArray().map((e) => {
     return {


### PR DESCRIPTION
# エラー
https://github.com/prickathon/prismdb/runs/6936101651?check_suite_focus=true#step:3:25

```
Error: unable to verify the first certificate
    at TLSSocket.onConnectSecure (node:_tls_wrap:1532:34)
    at TLSSocket.emit (node:events:527:28)
    at TLSSocket.emit (node:domain:475:12)
    at TLSSocket._finishInit (node:_tls_wrap:946:8)
    at TLSWrap.ssl.onhandshakedone (node:_tls_wrap:727:12) {
```

# 詳細
ググったら下記が見つかったので適用したらなおりました。

* https://r17n.page/2020/04/29/nodejs-axios-ignore-ssl-error/
* https://github.com/axios/axios/issues/535#issuecomment-260841069

オレオレ証明書を使ってるとなるらしいんだけど https://primagi.jp/ を見る感じ特に問題なさそうに見える...