### PR TITLE
Upgrade to actions/checkout@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: prepara rdfs
         working-directory: csv2rdf

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: prepara rdfs
         working-directory: csv2rdf

--- a/.github/workflows/rdflint.yml
+++ b/.github/workflows/rdflint.yml
@@ -6,7 +6,7 @@ jobs:
   rdflint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v1
         with:
           java-version: 11

--- a/.github/workflows/re-generate.yml
+++ b/.github/workflows/re-generate.yml
@@ -8,7 +8,7 @@ jobs:
   re-generate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - working-directory: csv2rdf
       name: update shops
       run: |


### PR DESCRIPTION
https://github.com/prickathon/prismdb/actions/runs/3649676684 に

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: lazy-actions/slatify@master

のようなdeprecation warningがあったので修正しました。

`lazy-actions/slatify@master` の方は https://github.com/lazy-actions/slatify/pull/99 がマージされればなおります