### PR TITLE
re-generate workflowがエラーになっているのを修正

### DIFF
--- a/.github/workflows/re-generate.yml
+++ b/.github/workflows/re-generate.yml
@@ -14,8 +14,8 @@ jobs:
       name: update shops
       run: |
         npm ci
-        $(npm bin)/ts-node tools/update-shops-primagi.ts
-        $(npm bin)/ts-node tools/update-shops-prismstone.ts
+        npx ts-node tools/update-shops-primagi.ts
+        npx ts-node tools/update-shops-prismstone.ts
     - uses: tibdex/github-app-token@v1
       id: generate-token
       with:

--- a/.github/workflows/re-generate.yml
+++ b/.github/workflows/re-generate.yml
@@ -10,6 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        # FIXME: 最新にするとtools/update-shops-prismstone.tsのaxios.getで下記のようなエラーになるので16で止めている
+        #        Error: write EPROTO C067081E767F0000:error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled:../deps/openssl/openssl/ssl/statem/extensions.c:922:
+        node-version: 16
+
+        cache: npm
+        cache-dependency-path: csv2rdf/package-lock.json
     - working-directory: csv2rdf
       name: update shops
       run: |

--- a/.github/workflows/re-generate.yml
+++ b/.github/workflows/re-generate.yml
@@ -3,6 +3,7 @@ name: re-generate
 on:
   schedule:
     - cron: '0 */12 * * *'
+  push:
 
 jobs:
   re-generate:
@@ -20,6 +21,7 @@ jobs:
       with:
         app_id: ${{ secrets.GH_APPS_ID }}
         private_key: ${{ secrets.GH_APPS_PRIVATE_KEY }}
+      if: github.event_name == 'schedule'
     - uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ steps.generate-token.outputs.token }}
@@ -29,6 +31,7 @@ jobs:
           お店情報の自動アップデートです！ #274
         labels: |
           automerge
+      if: github.event_name == 'schedule'
     - name: Slack Notification
       uses: lazy-actions/slatify@master
       if: "! success()" # cronで実行されるので失敗時のみ通知する

--- a/.github/workflows/re-generate.yml
+++ b/.github/workflows/re-generate.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 */12 * * *'
   push:
+  pull_request:
 
 jobs:
   re-generate:

--- a/csv2rdf/package-lock.json
+++ b/csv2rdf/package-lock.json
@@ -1,98 +1,115 @@
 {
   "name": "prismdb-csv2rdf",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/cheerio": {
+  "packages": {
+    "": {
+      "name": "prismdb-csv2rdf",
+      "version": "1.0.0",
+      "dependencies": {
+        "axios": "^0.21.2",
+        "cheerio": "^1.0.0-rc.12"
+      },
+      "devDependencies": {
+        "@types/cheerio": "^0.22.13",
+        "@types/n3": "^1.0.7",
+        "async-csv": "^2.1.3",
+        "n3": "^1.1.1",
+        "rimraf": "^2.6.3",
+        "ts-node": "^8.1.0",
+        "typescript": "^3.4.5"
+      }
+    },
+    "node_modules/@types/cheerio": {
       "version": "0.22.13",
       "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.13.tgz",
       "integrity": "sha512-OZd7dCUOUkiTorf97vJKwZnSja/DmHfuBAroe1kREZZTCf/tlFecwHhsOos3uVHxeKGZDwzolIrCUApClkdLuA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/node": "*"
       }
     },
-    "@types/n3": {
+    "node_modules/@types/n3": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.0.7.tgz",
       "integrity": "sha512-YxMnEoJhkr9z2KOhjHQvBM6hq4Swri7xW8ZJ1LTwDL1n19mgRojdKj+yK6FSKHZNx+7fK9by/kUH8fpuYWMbRA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/node": "*",
         "@types/rdf-js": "*"
       }
     },
-    "@types/node": {
+    "node_modules/@types/node": {
       "version": "11.13.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.9.tgz",
       "integrity": "sha512-NJ4yuEVw5podZbINp3tEqUIImMSAEHaCXRiWCf3KC32l6hIKf0iPJEh2uZdT0fELfRYk310yLmMXqy2leZQUbg==",
       "dev": true
     },
-    "@types/rdf-js": {
+    "node_modules/@types/rdf-js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.1.tgz",
       "integrity": "sha512-x3Qct8TPilUos4znM1gANmtTvjOFdDRItmpEM2Nu9QgAx258FN9k22OvOu2TmPzOlx8a1FLdEW3o33UXHQt5ow==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/node": "*"
       }
     },
-    "arg": {
+    "node_modules/arg": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
       "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
       "dev": true
     },
-    "async-csv": {
+    "node_modules/async-csv": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/async-csv/-/async-csv-2.1.3.tgz",
       "integrity": "sha512-mpsCN+D7mzZeqrlDw7UTPhvDQDlx1i819E9fbKIt8drkgED5FSOlBv3Rk/+sXdevnO2wwlRkVOQ4kdT0AyqPqQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "csv": "^5.1.3"
       }
     },
-    "axios": {
+    "node_modules/axios": {
       "version": "0.21.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
       "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
-      "requires": {
+      "dependencies": {
         "follow-redirects": "^1.14.0"
       }
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "boolbase": {
+    "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "buffer-from": {
+    "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "cheerio": {
+    "node_modules/cheerio": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
       "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-      "requires": {
+      "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
@@ -100,303 +117,419 @@
         "htmlparser2": "^8.0.1",
         "parse5": "^7.0.0",
         "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
       }
     },
-    "cheerio-select": {
+    "node_modules/cheerio-select": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
       "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "requires": {
+      "dependencies": {
         "boolbase": "^1.0.0",
         "css-select": "^5.1.0",
         "css-what": "^6.1.0",
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "css-select": {
+    "node_modules/css-select": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
       "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "requires": {
+      "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
         "domhandler": "^5.0.2",
         "domutils": "^3.0.1",
         "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
-    "css-what": {
+    "node_modules/css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
     },
-    "csv": {
+    "node_modules/csv": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/csv/-/csv-5.3.2.tgz",
       "integrity": "sha512-odDyucr9OgJTdGM2wrMbJXbOkJx3nnUX3Pt8SFOwlAMOpsUQlz1dywvLMXJWX/4Ib0rjfOsaawuuwfI5ucqBGQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "csv-generate": "^3.2.4",
         "csv-parse": "^4.8.8",
         "csv-stringify": "^5.3.6",
         "stream-transform": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.1.90"
       }
     },
-    "csv-generate": {
+    "node_modules/csv-generate": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.2.4.tgz",
       "integrity": "sha512-qNM9eqlxd53TWJeGtY1IQPj90b563Zx49eZs8e0uMyEvPgvNVmX1uZDtdzAcflB3PniuH9creAzcFOdyJ9YGvA==",
       "dev": true
     },
-    "csv-parse": {
+    "node_modules/csv-parse": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.12.0.tgz",
       "integrity": "sha512-wPQl3H79vWLPI8cgKFcQXl0NBgYYEqVnT1i6/So7OjMpsI540oD7p93r3w6fDSyPvwkTepG05F69/7AViX2lXg==",
       "dev": true
     },
-    "csv-stringify": {
+    "node_modules/csv-stringify": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.5.1.tgz",
       "integrity": "sha512-HM0/86Ks8OwFbaYLd495tqTs1NhscZL52dC4ieKYumy8+nawQYC0xZ63w1NqLf0M148T2YLYqowoImc1giPn0g==",
       "dev": true
     },
-    "diff": {
+    "node_modules/diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
-    "dom-serializer": {
+    "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "requires": {
+      "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
         "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
-    "domelementtype": {
+    "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
-    "domhandler": {
+    "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "requires": {
+      "dependencies": {
         "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
-    "domutils": {
+    "node_modules/domutils": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
       "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "requires": {
+      "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
-    "entities": {
+    "node_modules/entities": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
-    "follow-redirects": {
+    "node_modules/follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "htmlparser2": {
+    "node_modules/htmlparser2": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
       "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
-      "requires": {
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
         "domutils": "^3.0.1",
         "entities": "^4.3.0"
       }
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "make-error": {
+    "node_modules/make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "n3": {
+    "node_modules/n3": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/n3/-/n3-1.1.1.tgz",
       "integrity": "sha512-GEJXn+wc0f4l2noP1N/rMUH9Gei1DQ8IDN03eBsH+uQKkNQUOLgL7ZJVaDjY+pP3LmbLxL1LpUg/AvZ7Kc7KVw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8.0"
+      }
     },
-    "nth-check": {
+    "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "requires": {
+      "dependencies": {
         "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "parse5": {
+    "node_modules/parse5": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "requires": {
+      "dependencies": {
         "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "parse5-htmlparser2-tree-adapter": {
+    "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
       "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-      "requires": {
+      "dependencies": {
         "domhandler": "^5.0.2",
         "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "rimraf": {
+    "node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
-    "source-map": {
+    "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "source-map-support": {
+    "node_modules/source-map-support": {
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
       "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
     },
-    "stream-transform": {
+    "node_modules/stream-transform": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz",
       "integrity": "sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==",
       "dev": true,
-      "requires": {
-        "mixme": "^0.5.1"
-      },
       "dependencies": {
-        "mixme": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.4.tgz",
-          "integrity": "sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==",
-          "dev": true
-        }
+        "mixme": "^0.5.1"
       }
     },
-    "ts-node": {
+    "node_modules/stream-transform/node_modules/mixme": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.4.tgz",
+      "integrity": "sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ts-node": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.1.0.tgz",
       "integrity": "sha512-34jpuOrxDuf+O6iW1JpgTRDFynUZ1iEqtYruBqh35gICNjN8x+LpVcPAcwzLPi9VU6mdA3ym+x233nZmZp445A==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "arg": "^4.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
         "yn": "^3.0.0"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.0"
       }
     },
-    "typescript": {
+    "node_modules/typescript": {
       "version": "3.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
       "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "yn": {
+    "node_modules/yn": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
       "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }


### PR DESCRIPTION
@takanakahiko https://github.com/prickathon/prismdb/actions/runs/4208902005/jobs/7305417368 以降re-generate workflowがエラーになっているのを修正しました

# 原因
81f2476e799f1afdfef80d944739c43ed687df96 を見る感じ、GitHub ActionsのRunnerに入っているnpmがv9以降にバージョンアップしたことで `npm bin` がなくなってエラーになっているようでした。

https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/

nodeを最新にすると今度はSSL関係のエラーが出るため(2d8f0a6f24c17bf8887109bb7a6984667bc02979 参照)、node 16を使うようにしています。

# その他の修正
エラー修正以外にも細かいところで下記の対応も行っています。

* 4b9bc6a  `npm WARN old lockfile`の修正
* 7d48fb4 a8e3269 動作確認しやすいようにschedule以外でもupdate shopsだけは実行するようにした